### PR TITLE
Arithmetic Overflow on orders with amount above ~`341e18`

### DIFF
--- a/test/LimitOrderRegistry.t.sol
+++ b/test/LimitOrderRegistry.t.sol
@@ -68,6 +68,16 @@ contract LimitOrderRegistryTest is Test {
         registry.setupLimitOrder(USDC_WETH_05_POOL, 10e18);
     }
 
+    function test_OverflowingNewOrder() public {
+        uint96 amount = 340_316_398_560_794_542_918;
+        address msgSender = 0xE0b906ae06BfB1b54fad61E222b2E324D51e1da6;
+        deal(address(USDC), msgSender, amount);
+        vm.startPrank(msgSender);
+        USDC.approve(address(registry), amount);
+
+        registry.newOrder(USDC_WETH_05_POOL, 204900, amount, true, 0);
+    }
+
     // ========================================= INITIALIZATION TEST =========================================
 
     // ============================================= HAPPY PATH TEST =============================================


### PR DESCRIPTION
Hey gang,

Attempting to create a new order with amount above ~`341e18` will revert due to arithmetic overflow in `LimitOrderRegistry._mintPosition`.

Specifically, these lines:

```solidity
uint128 amount0Min = amount0 == 0 ? 0 : (amount0 * 0.9999e18) / 1e18;
uint128 amount1Min = amount1 == 0 ? 0 : (amount1 * 0.9999e18) / 1e18;
```

They should cast appropriately before performing arithmetic. Suggested mitigation:

```solidity
uint128 amount0Min = amount0 == 0 ? 0 : uint128((uint256(amount0) * 0.9999e18) / 1e18);
uint128 amount1Min = amount1 == 0 ? 0 : uint128((uint256(amount1) * 0.9999e18) / 1e18);
```

Not that these lines appear in both `_mintPosition` and `_addToPosition`