### PR TITLE
Introduce invariant test suite

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,3 +7,8 @@ auto_detect_solc = false
 # eth_rpc_url = "YOUR_ALCHEMY_HTTPS_URL_HERE"
 # etherscan_api_key = "YOUR_ETHERSCAN_API_KEY_HERE"
 block_number = 15000000
+
+[invariant]
+runs = 1
+depth = 256
+fail_on_revert = true

--- a/test/invariants/Handler.t.sol
+++ b/test/invariants/Handler.t.sol
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import { LimitOrderRegistry } from "src/LimitOrderRegistry.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { UniswapV3Pool as IUniswapV3Pool } from "src/interfaces/uniswapV3/UniswapV3Pool.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { Helpers } from "./Helpers.t.sol";
+import "forge-std/Test.sol";
+
+contract Handler is Helpers {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
+
+    /// @dev Mimics Event from LimitOrderRegistry
+    error LimitOrderRegistry__OrderITM(int24 currentTick, int24 targetTick, bool direction);
+
+    /// @dev Immutable vars
+    LimitOrderRegistry internal immutable i_registry;
+    ERC20 internal immutable i_usdc;
+    ERC20 internal immutable i_weth;
+    IUniswapV3Pool internal immutable i_pool;
+
+    /// Ghost vars ///
+    /// New orders
+    uint256 internal s_newOrderAttempts;
+    uint256 internal s_newOrderSuccesses;
+    uint256 internal s_newOrderFailLO;
+    uint256 internal s_newOrderFailPriceSlippageCheck;
+    uint256 internal s_newOrderFailOther;
+
+    struct OrderDetails {
+        int24 targetTick;
+        bool direction;
+    }
+    // LP address => batchId => OrderDetails
+
+    mapping(address => mapping(uint128 => OrderDetails)) internal s_lpOrders;
+    // BatchIds => Addresses
+    mapping(uint128 => EnumerableSet.AddressSet) internal s_batchIdAddresses;
+    EnumerableSet.UintSet internal s_batchIds;
+    // BatchIds filled by upkeeps
+    EnumerableSet.UintSet internal s_filledBatchIds;
+
+    /// Tracking Success and Fails ///
+    uint256 internal s_cancelOrderAttempts;
+    uint256 internal s_cancelOrderSuccesses;
+    uint256 internal s_cancelOrderFail;
+
+    uint256 internal s_swapAttempts;
+    uint256 internal s_swapSuccess;
+    uint256 internal s_swapFail;
+
+    uint256 internal s_upkeepAttempts;
+    uint256 internal s_upkeepSuccesses;
+    uint256 internal s_upkeepSkips;
+
+    uint256 internal s_claimAttempts;
+    uint256 internal s_claimSuccesses;
+    uint256 internal s_claimFail;
+
+    uint256 internal s_pokes;
+
+    constructor(LimitOrderRegistry registry, ERC20 usdc, ERC20 weth, IUniswapV3Pool pool) {
+        i_registry = registry;
+        i_usdc = usdc;
+        i_weth = weth;
+        i_pool = pool;
+    }
+
+    /// @dev Place order
+    function placeNewOrder(uint24 tickDiff, uint256 amount, bool direction, uint256) public {
+        s_newOrderAttempts++;
+        amount = bound(amount, 1e4, type(uint104).max);
+        (address msgSender, ) = _randomSigner();
+        changePrank(msgSender);
+        tickDiff = uint24(bound(uint256(tickDiff), 20, 100));
+        ERC20 token = direction ? i_usdc : i_weth;
+        (, int24 currentTick, , , , , ) = i_pool.slot0();
+        int24 tickSpacing = i_pool.tickSpacing();
+        int24 targetTick = currentTick + (direction ? int24(tickDiff) : -int24(tickDiff));
+        if (direction) {
+            while (targetTick % tickSpacing != 0) {
+                targetTick += int24(1);
+            }
+        } else {
+            while (targetTick % tickSpacing != 0) {
+                targetTick -= int24(1);
+            }
+        }
+        deal(address(token), msgSender, amount);
+        token.approve(address(i_registry), amount);
+        try i_registry.newOrder(i_pool, targetTick, uint96(amount), direction, 0, type(uint256).max) returns (
+            uint128 batchId
+        ) {
+            OrderDetails memory details = OrderDetails(targetTick, direction);
+            // add address and details
+            s_lpOrders[msgSender][batchId] = details;
+            s_batchIdAddresses[batchId].add(msgSender);
+            // add batchId
+            s_batchIds.add(batchId);
+            s_newOrderSuccesses++;
+        } catch (bytes memory reason) {
+            if (keccak256(bytes(_getRevertMsg(reason))) == keccak256(bytes("LO"))) {
+                s_newOrderFailLO++;
+            } else if (keccak256(bytes(_getRevertMsg(reason))) == keccak256(bytes("Price slippage check"))) {
+                s_newOrderFailPriceSlippageCheck++;
+            } else {
+                s_newOrderFailOther++;
+            }
+        }
+    }
+
+    /// @dev cancelOrder
+    function cancelOrder(uint256 index) public {
+        if (s_batchIds.length() == 0) {
+            console.log("No orders to cancel");
+            return;
+        }
+        s_cancelOrderAttempts++;
+
+        index = bound(index, 0, s_batchIds.length() - 1);
+        uint128 batchId = uint128(s_batchIds.at(index));
+        // TODO: Change so that it gets a batchId that is not filled
+        if (s_filledBatchIds.contains(batchId)) {
+            console.log("Batch ID %s already filled", batchId);
+            return;
+        }
+        address msgSender = s_batchIdAddresses[batchId].at(0);
+
+        OrderDetails memory details = s_lpOrders[msgSender][batchId];
+
+        changePrank(msgSender);
+        try i_registry.cancelOrder(i_pool, details.targetTick, details.direction, type(uint256).max) returns (
+            uint128,
+            uint128,
+            uint128 returnedBatchId
+        ) {
+            assertEq(batchId, returnedBatchId);
+            s_cancelOrderSuccesses++;
+            // remove address from orders
+            s_lpOrders[msgSender][batchId] = OrderDetails(0, false);
+
+            // remove address from batchIds
+            s_batchIdAddresses[batchId].remove(msgSender);
+            if (s_batchIdAddresses[batchId].length() == 0) {
+                s_batchIds.remove(batchId);
+            }
+        } catch (bytes memory) {
+            s_cancelOrderFail++;
+        }
+    }
+
+    /// @dev Swap
+    function swap(bool zeroForOne, uint64 amountSpecified) public {
+        s_swapAttempts++;
+        if (amountSpecified == 0) {
+            amountSpecified = 1;
+        }
+        if (zeroForOne) {
+            deal(address(i_usdc), address(this), amountSpecified);
+        } else {
+            deal(address(i_weth), address(this), amountSpecified);
+        }
+        changePrank(address(this));
+        try
+            i_pool.swap(
+                address(this),
+                zeroForOne,
+                int64(amountSpecified),
+                (zeroForOne ? 4295128740 : 1461446703485210103287273052203988822378723970341),
+                ""
+            )
+        returns (int256, int256) {
+            s_swapSuccess++;
+        } catch (bytes memory reason) {
+            if (keccak256(bytes(_getRevertMsg(reason))) == keccak256(bytes("SPL"))) {
+                s_swapFail++;
+            } else {
+                revert();
+            }
+        }
+    }
+
+    /// @dev Check and perform Upkeep
+    function performUpkeep() public {
+        s_upkeepAttempts++;
+        (bool upkeepNeeded, bytes memory performData) = i_registry.checkUpkeep(abi.encode(i_pool));
+        if (upkeepNeeded) {
+            vm.recordLogs();
+            i_registry.performUpkeep(performData);
+            Vm.Log[] memory logs = vm.getRecordedLogs();
+            for (uint256 i = 0; i < logs.length; i++) {
+                if (logs[i].topics[0] == keccak256("OrderFilled(uint256,address)")) {
+                    (uint256 batchId, ) = abi.decode(logs[i].data, (uint256, address));
+                    s_filledBatchIds.add(batchId);
+                }
+            }
+            s_upkeepSuccesses++;
+        } else {
+            s_upkeepSkips++;
+        }
+    }
+
+    /// @dev Claim orders - Claims all orders in a certain batch ID
+    function claimOrders(uint256 index) public {
+        if (s_filledBatchIds.length() == 0) {
+            console.log("No orders to claim");
+            return;
+        }
+        s_claimAttempts++;
+        index = bound(index, 0, s_filledBatchIds.length() - 1);
+        uint128 batchId = uint128(s_filledBatchIds.at(index));
+        for (uint256 i = 0; i < s_batchIdAddresses[batchId].length(); i++) {
+            address msgSender = s_batchIdAddresses[batchId].at(i);
+            changePrank(msgSender);
+            uint128 fee = i_registry.getFeePerUser(batchId);
+            deal(msgSender, fee + 1 ether);
+            (, uint256 amountOwed) = i_registry.claimOrder{ value: fee }(batchId, msgSender);
+            assertGt(amountOwed, 0);
+            // zero s_lpOrders
+            s_lpOrders[msgSender][batchId] = OrderDetails(0, false);
+            s_claimSuccesses++;
+        }
+        // remove batchId from s_batchIds
+        s_batchIds.remove(batchId);
+        // remove batchId from s_filledBatchIds
+        s_filledBatchIds.remove(batchId);
+        // remove all addresses from s_batchIdAddresses
+        uint256 j = 0;
+        while (j < s_batchIdAddresses[batchId].length()) {
+            s_batchIdAddresses[batchId].remove(s_batchIdAddresses[batchId].at(0));
+            j++;
+        }
+    }
+
+    /// TODO Provide liquidity directly to pool
+
+    /// @dev Push blockchain one block and 12 seconds in the future
+    function pokeBlockchain() public {
+        s_pokes++;
+        skip(12);
+        vm.roll(block.number + 1);
+    }
+
+    ///////// HELPERS /////////
+
+    /// @dev Prints ghost vars
+    function printGhosts() public view {
+        console.log(
+            "Total Attempts: %s",
+            (s_newOrderAttempts + s_cancelOrderAttempts + s_swapAttempts + s_upkeepAttempts + s_claimAttempts)
+        );
+        console.log(
+            "Total Success: %s",
+            (s_newOrderSuccesses + s_cancelOrderSuccesses + s_swapSuccess + s_upkeepSuccesses + s_claimSuccesses)
+        );
+        console.log(
+            "Total Fail: %s",
+            (s_newOrderFailLO +
+                s_newOrderFailPriceSlippageCheck +
+                s_newOrderFailOther +
+                s_cancelOrderFail +
+                s_swapFail +
+                s_claimFail +
+                s_upkeepSkips)
+        );
+        console.log("s_newOrderAttempts: %s", s_newOrderAttempts);
+        console.log("s_newOrderSuccesses: %s", s_newOrderSuccesses);
+        console.log("s_newOrderFailLO: %s", s_newOrderFailLO);
+        console.log("s_newOrderFailPriceSlippageCheck: %s", s_newOrderFailPriceSlippageCheck);
+        console.log("s_newOrderFailOther: %s", s_newOrderFailOther);
+        console.log("s_cancelOrderAttempts: %s", s_cancelOrderAttempts);
+        console.log("s_cancelOrderSuccesses: %s", s_cancelOrderSuccesses);
+        console.log("s_cancelOrderFail: %s", s_cancelOrderFail);
+        console.log("s_swapAttempts: %s", s_swapAttempts);
+        console.log("s_swapSuccess: %s", s_swapSuccess);
+        console.log("s_swapFail: %s", s_swapFail);
+        console.log("s_upkeepAttempts: %s", s_upkeepAttempts);
+        console.log("s_upkeepSuccesses: %s", s_upkeepSuccesses);
+        console.log("s_upkeepSkips: %s", s_upkeepSkips);
+        console.log("s_claimAttempts: %s", s_claimAttempts);
+        console.log("s_claimSuccesses: %s", s_claimSuccesses);
+        console.log("s_claimFail: %s", s_claimFail);
+        console.log("s_pokes: %s", s_pokes);
+    }
+
+    function getBatchIds() public view returns (uint256[] memory) {
+        return s_batchIds.values();
+    }
+
+    /// @dev Required for Uniswap swaps
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata) external {
+        if (amount0Delta > 0) {
+            deal(address(i_usdc), address(this), uint256(amount0Delta));
+            i_usdc.transfer(msg.sender, uint256(amount0Delta));
+        } else if (amount1Delta > 0) {
+            deal(address(i_weth), address(this), uint256(amount1Delta));
+            i_weth.transfer(msg.sender, uint256(amount1Delta));
+        }
+    }
+}

--- a/test/invariants/Helpers.t.sol
+++ b/test/invariants/Helpers.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+
+contract Helpers is Test {
+    function _getRevertMsg(bytes memory _returnData) internal pure returns (string memory) {
+        // If the _res length is less than 68, then the transaction failed silently (without a revert message)
+        if (_returnData.length < 68) return "Transaction reverted silently";
+
+        assembly {
+            // Slice the sighash.
+            _returnData := add(_returnData, 0x04)
+        }
+        return abi.decode(_returnData, (string)); // All that remains is the revert string
+    }
+
+    function _contains(string memory where, string memory what) internal pure returns (bool found) {
+        bytes memory whatBytes = bytes(what);
+        bytes memory whereBytes = bytes(where);
+
+        require(whereBytes.length >= whatBytes.length);
+
+        for (uint256 i = 0; i <= whereBytes.length - whatBytes.length; i++) {
+            bool flag = true;
+            for (uint256 j = 0; j < whatBytes.length; j++) {
+                if (whereBytes[i + j] != whatBytes[j]) {
+                    flag = false;
+                    break;
+                }
+            }
+            if (flag) {
+                found = true;
+                break;
+            }
+        }
+    }
+
+    /// @dev Returns a random signer and its private key.
+    function _randomSigner() internal returns (address signer, uint256 privateKey) {
+        uint256 privateKeyMax = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140;
+        privateKey = __bound(_random(), 1, privateKeyMax);
+        signer = vm.addr(privateKey);
+    }
+
+    /// @dev Returns a pseudorandom random number from [0 .. 2**256 - 1] (inclusive).
+    /// For usage in fuzz tests, please ensure that the function has an unnamed uint256 argument.
+    /// e.g. `testSomething(uint256) public`.
+    function _random() internal returns (uint256 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // This is the keccak256 of a very long string I randomly mashed on my keyboard.
+            let sSlot := 0xd715531fe383f818c5f158c342925dcf01b954d24678ada4d07c36af0f20e1ee
+            let sValue := sload(sSlot)
+
+            mstore(0x20, sValue)
+            r := keccak256(0x20, 0x40)
+
+            // If the storage is uninitialized, initialize it to the keccak256 of the calldata.
+            if iszero(sValue) {
+                sValue := sSlot
+                let m := mload(0x40)
+                calldatacopy(m, 0, calldatasize())
+                r := keccak256(m, calldatasize())
+            }
+            sstore(sSlot, add(r, 1))
+
+            // Do some biased sampling for more robust tests.
+            // prettier-ignore
+            for {} 1 {} {
+                let d := byte(0, r)
+                // With a 1/256 chance, randomly set `r` to any of 0,1,2.
+                if iszero(d) {
+                    r := and(r, 3)
+                    break
+                }
+                // With a 1/2 chance, set `r` to near a random power of 2.
+                if iszero(and(2, d)) {
+                    // Set `t` either `not(0)` or `xor(sValue, r)`.
+                    let t := xor(not(0), mul(iszero(and(4, d)), not(xor(sValue, r))))
+                    // Set `r` to `t` shifted left or right by a random multiple of 8.
+                    switch and(8, d)
+                    case 0 {
+                        if iszero(and(16, d)) { t := 1 }
+                        r := add(shl(shl(3, and(byte(3, r), 31)), t), sub(and(r, 7), 3))
+                    }
+                    default {
+                        if iszero(and(16, d)) { t := shl(255, 1) }
+                        r := add(shr(shl(3, and(byte(3, r), 31)), t), sub(and(r, 7), 3))
+                    }
+                    // With a 1/2 chance, negate `r`.
+                    if iszero(and(32, d)) { r := not(r) }
+                    break
+                }
+                // Otherwise, just set `r` to `xor(sValue, r)`.
+                r := xor(sValue, r)
+                break
+            }
+        }
+    }
+
+    /// @dev Adapted from:
+    /// https://github.com/foundry-rs/forge-std/blob/ff4bf7db008d096ea5a657f2c20516182252a3ed/src/StdUtils.sol#L10
+    /// Differentially fuzzed tested against the original implementation.
+    function __bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
+        require(min <= max, "__bound(uint256,uint256,uint256): Max is less than min.");
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // prettier-ignore
+            for {} 1 {} {
+                // If `x` is between `min` and `max`, return `x` directly.
+                // This is to ensure that dictionary values
+                // do not get shifted if the min is nonzero.
+                // More info: https://github.com/foundry-rs/forge-std/issues/188
+                if iszero(or(lt(x, min), gt(x, max))) {
+                    result := x
+                    break
+                }
+
+                let size := add(sub(max, min), 1)
+                if and(iszero(gt(x, 3)), gt(size, x)) {
+                    result := add(min, x)
+                    break
+                }
+
+                let w := not(0)
+                if and(iszero(lt(x, sub(0, 4))), gt(size, sub(w, x))) {
+                    result := sub(max, sub(w, x))
+                    break
+                }
+
+                // Otherwise, wrap x into the range [min, max],
+                // i.e. the range is inclusive.
+                if iszero(lt(x, max)) {
+                    let d := sub(x, max)
+                    let r := mod(d, size)
+                    if iszero(r) {
+                        result := max
+                        break
+                    }
+                    result := add(add(min, r), w)
+                    break
+                }
+                let d := sub(min, x)
+                let r := mod(d, size)
+                if iszero(r) {
+                    result := min
+                    break
+                }
+                result := add(sub(max, r), 1)
+                break
+            }
+        }
+    }
+}

--- a/test/invariants/Invariants.t.sol
+++ b/test/invariants/Invariants.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {LimitOrderRegistry} from "src/LimitOrderRegistry.sol";
+import {NonFungiblePositionManager as INonFungiblePositionManager} from
+    "src/interfaces/uniswapV3/NonFungiblePositionManager.sol";
+import {UniswapV3Pool as IUniswapV3Pool} from "src/interfaces/uniswapV3/UniswapV3Pool.sol";
+import {IUniswapV3Router} from "src/interfaces/uniswapV3/IUniswapV3Router.sol";
+import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/interfaces/LinkTokenInterface.sol";
+import {IKeeperRegistrar as KeeperRegistrar} from "src/interfaces/chainlink/IKeeperRegistrar.sol";
+import {Handler} from "./Handler.t.sol";
+
+contract Invariants is Test {
+    LimitOrderRegistry public registry;
+
+    INonFungiblePositionManager private positionManger =
+        INonFungiblePositionManager(0xC36442b4a4522E871399CD717aBDD847Ab11FE88);
+
+    IUniswapV3Router private router = IUniswapV3Router(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    LinkTokenInterface private LINK = LinkTokenInterface(0xb0897686c545045aFc77CF20eC7A532E3120E0F1);
+
+    KeeperRegistrar private REGISTRAR = KeeperRegistrar(0x9a811502d843E5a03913d5A2cfb646c11463467A);
+    KeeperRegistrar private REGISTRAR_V1 = KeeperRegistrar(0xDb8e8e2ccb5C033938736aa89Fe4fa1eDfD15a1d);
+
+    ERC20 private USDC = ERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    ERC20 private WETH = ERC20(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
+    ERC20 private WMATIC = ERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+
+    IUniswapV3Pool private USDC_WETH_05_POOL = IUniswapV3Pool(0x45dDa9cb7c25131DF268515131f647d726f50608);
+    IUniswapV3Pool private USDC_WETH_3_POOL = IUniswapV3Pool(0x0e44cEb592AcFC5D3F09D996302eB4C499ff8c10);
+
+    address private fastGasFeed = address(0);
+
+    // Token Ids for polygon block number 37834659.
+    uint256 private id0 = 614120;
+    uint256 private id1 = 614121;
+    uint256 private id2 = 614122;
+    uint256 private id3 = 614123;
+    uint256 private id4 = 614124;
+    uint256 private id5 = 614125;
+    uint256 private id6 = 614126;
+    uint256 private id7 = 614127;
+    uint256 private id8 = 614128;
+    uint256 private id9 = 614129;
+    uint256 private id10 = 614130;
+    uint256 private id11 = 614131;
+    uint256 private id12 = 614132;
+    uint256 private id13 = 614133;
+    uint256 private id14 = 614134;
+    uint256 private id15 = 614135;
+    uint256 private id16 = 614136;
+    uint256 private id17 = 614137;
+    uint256 private id18 = 614138;
+    uint256 private id19 = 614139;
+
+    Handler internal s_handler;
+
+    function setUp() public {
+        registry = new LimitOrderRegistry(address(this), positionManger, WMATIC, LINK, REGISTRAR, fastGasFeed);
+        registry.setMinimumAssets(1, USDC);
+        registry.setMinimumAssets(1, WETH);
+
+        // deal(address(LINK), address(this), 10e18);
+        // LINK.approve(address(registry), 10e18);
+        registry.setupLimitOrder(USDC_WETH_05_POOL, 0);
+        s_handler = new Handler(registry, USDC, WETH, USDC_WETH_05_POOL);
+
+        // add the handler selectors to the fuzzing targets
+        bytes4[] memory selectors = new bytes4[](10);
+        selectors[0] = Handler.pokeBlockchain.selector;
+        // Added multiple times to increase the probability of being selected
+        selectors[1] = Handler.placeNewOrder.selector;
+        selectors[2] = Handler.placeNewOrder.selector;
+        selectors[3] = Handler.cancelOrder.selector;
+        selectors[4] = Handler.performUpkeep.selector;
+        // Added multiple times to increase the probability of being selected
+        // as swaps are the most common operation.
+        selectors[5] = Handler.swap.selector;
+        selectors[6] = Handler.swap.selector;
+        selectors[7] = Handler.swap.selector;
+        selectors[8] = Handler.swap.selector;
+        selectors[9] = Handler.claimOrders.selector;
+
+        targetSelector(FuzzSelector({addr: address(s_handler), selectors: selectors}));
+        targetContract(address(s_handler));
+
+        vm.startPrank(address(s_handler));
+    }
+
+    /// @dev Print ghost variables to the console when run with -vvv
+    function invariant_printGhosts() public view {
+        s_handler.printGhosts();
+    }
+
+    /// @dev This will fail if these views revert at any point
+    function invariant_viewsShouldNotRevert() public view {
+        registry.getGasPrice();
+        registry.checkUpkeep(abi.encode(USDC_WETH_05_POOL));
+        uint256[] memory ids = s_handler.getBatchIds();
+        if (ids.length > 0) {
+            uint128 id = uint128(ids[0]);
+            registry.getFeePerUser(id);
+            registry.isOrderReadyForClaim(id);
+            registry.getClaim(id);
+        }
+    }
+}


### PR DESCRIPTION
Hey guys!

I'm dropping the invariant test suite we built alongside our audit here. This is credited with finding the original overflow bug mentioned a few weeks ago in a separate PR. These tests are a good starting point but need expansion for better simulation. They currently pass with the command:

```bash
forge test -vvv --match-test invariant_ --fork-url https://polygon-mainnet.g.alchemy.com/v2/<YOUR_KEY_HERE> --fork-block-number 37834659
```

## `Invariants.t.sol` - Invariant Definitions

`Invariants.t.sol` is where the test environment is set up, and the invariants for the system are defined. The environment copies the one setup in `LimitOrderRegistry.t.sol`, but uses only the `USDC_WETH_05_POOL`. It also describes the valid actions that the fuzzer can perform (handler selectors in `setUp`. More on this later).

The invariants are defined as functions prefixed with `invariant_`. We have struggled to define some invariants, but the ones present were enough to sniff out some overflow bugs (as previously mentioned). If you can think of any facts that should always be true no matter what future state, add them to this file like this:

```solidity
function invariant_fiveShouldAlwaysBeBiggerThanFour() public {
    assertGt(5, 4);
}
```

This will be checked after every action that the fuzzer runs.

## `Handler.t.sol` - Valid Actions

Every valid action the fuzzer can call is defined within `Handler.t.sol`. These include:
* placing an order
* canceling an order
* performing a regular swap on the V3 pool
* checking and performing upkeep
* claiming orders
* poking the blockchain (increment block number and add 12 seconds to block timestamp)

Another function that needs to be done that would be good to implement here is providing liquidity directly to the pool.

The purpose of these actions is to provide a simulation of real life. If these valid actions can break the invariants defined in the `Invariants.t.sol` file, we got a problem.

## `Helpers.t.sol`

Helper functions for the Handler contract.

## More Invariant Content

* [Invariant Tests for Solidity (WETH)](https://mirror.xyz/horsefacts.eth/Jex2YVaO65dda6zEyfM_-DXlXhOWCAoSpOx5PLocYgw)
* [Cyfrin Invariant Example Walkthrough](https://betterprogramming.pub/invariant-testing-enter-the-matrix-c71363dea37e)